### PR TITLE
Fix/swc external helpers

### DIFF
--- a/change/@tensile-perf-react-8ecce907-a85d-4f04-9ee1-1f8796090fbc.json
+++ b/change/@tensile-perf-react-8ecce907-a85d-4f04-9ee1-1f8796090fbc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update SWC to include \"externalHelpers\"",
+  "packageName": "@tensile-perf/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@tensile-perf-runner-d787e5f0-e7b1-45d2-8f2e-89b695ecd217.json
+++ b/change/@tensile-perf-runner-d787e5f0-e7b1-45d2-8f2e-89b695ecd217.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update SWC to include \"externalHelpers\"",
+  "packageName": "@tensile-perf/runner",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@tensile-perf-tools-527abc6a-151c-4ebd-95fd-d9d382a400db.json
+++ b/change/@tensile-perf-tools-527abc6a-151c-4ebd-95fd-d9d382a400db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update SWC to include \"externalHelpers\"",
+  "packageName": "@tensile-perf/tools",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@tensile-perf-tree-b14c929e-dfff-443b-95e2-cd5df7e7d583.json
+++ b/change/@tensile-perf-tree-b14c929e-dfff-443b-95e2-cd5df7e7d583.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update SWC to include \"externalHelpers\"",
+  "packageName": "@tensile-perf/tree",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@tensile-perf-web-components-9332eb50-194a-4f8e-beb5-16ed59bcd613.json
+++ b/change/@tensile-perf-web-components-9332eb50-194a-4f8e-beb5-16ed59bcd613.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update SWC to include \"externalHelpers\"",
+  "packageName": "@tensile-perf/web-components",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/.swcrc
+++ b/packages/react/.swcrc
@@ -8,7 +8,7 @@
       "decorators": false,
       "dynamicImport": false
     },
-    "externalHelpers": true,
+    "externalHelpers": false,
     "transform": {
       "react": {
         "runtime": "classic",

--- a/packages/runner/.swcrc
+++ b/packages/runner/.swcrc
@@ -8,7 +8,7 @@
       "decorators": false,
       "dynamicImport": false
     },
-    "externalHelpers": true,
+    "externalHelpers": false,
     "transform": {
       "react": {
         "runtime": "classic",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@tensile-perf/tree": "0.1.6",
-    "chromedriver": "117.0.3",
+    "chromedriver": "121.0.0",
     "cli-table": "0.3.11",
     "edgedriver": "5.2.1",
     "ejs": "3.1.9",

--- a/packages/tools/.swcrc
+++ b/packages/tools/.swcrc
@@ -8,7 +8,7 @@
       "decorators": false,
       "dynamicImport": false
     },
-    "externalHelpers": true,
+    "externalHelpers": false,
     "transform": {
       "react": {
         "runtime": "classic",

--- a/packages/tree/.swcrc
+++ b/packages/tree/.swcrc
@@ -8,7 +8,7 @@
       "decorators": false,
       "dynamicImport": false
     },
-    "externalHelpers": true,
+    "externalHelpers": false,
     "transform": {
       "react": {
         "runtime": "classic",

--- a/packages/web-components/.swcrc
+++ b/packages/web-components/.swcrc
@@ -8,7 +8,7 @@
       "decorators": false,
       "dynamicImport": false
     },
-    "externalHelpers": true,
+    "externalHelpers": false,
     "transform": {
       "react": {
         "runtime": "classic",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3239,21 +3239,6 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@tensile-perf/tools@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@tensile-perf/tools/-/tools-0.1.6.tgz#b30adbe322769d872811f3f66220422fac686d20"
-  integrity sha512-BEw+vbus7M8D4rROZuMHKTbLyBhFGYPv8fJV81uElpPQLwWfVj3B/E73EIPbDt1lT8MQYq6MXoE4N9lSfaeFmw==
-  dependencies:
-    afterframe "1.0.2"
-    random-seedable "1.0.8"
-
-"@tensile-perf/tree@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@tensile-perf/tree/-/tree-0.1.6.tgz#3958402840a8b6b8a4d184507284084610109a32"
-  integrity sha512-SP1FZ63LGogoU1lGHK9vS3/qt4yX+W3LkMjO9QaZWp/p/02IiXZ0mlicIiiNBLbZvNPQfSU4yRSQ02gQAtfuYQ==
-  dependencies:
-    "@tensile-perf/tools" "0.1.6"
-
 "@testim/chrome-version@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.4.tgz#86e04e677cd6c05fa230dd15ac223fa72d1d7090"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3239,6 +3239,21 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
+"@tensile-perf/tools@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@tensile-perf/tools/-/tools-0.1.6.tgz#b30adbe322769d872811f3f66220422fac686d20"
+  integrity sha512-BEw+vbus7M8D4rROZuMHKTbLyBhFGYPv8fJV81uElpPQLwWfVj3B/E73EIPbDt1lT8MQYq6MXoE4N9lSfaeFmw==
+  dependencies:
+    afterframe "1.0.2"
+    random-seedable "1.0.8"
+
+"@tensile-perf/tree@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@tensile-perf/tree/-/tree-0.1.6.tgz#3958402840a8b6b8a4d184507284084610109a32"
+  integrity sha512-SP1FZ63LGogoU1lGHK9vS3/qt4yX+W3LkMjO9QaZWp/p/02IiXZ0mlicIiiNBLbZvNPQfSU4yRSQ02gQAtfuYQ==
+  dependencies:
+    "@tensile-perf/tools" "0.1.6"
+
 "@testim/chrome-version@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.4.tgz#86e04e677cd6c05fa230dd15ac223fa72d1d7090"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3239,7 +3239,7 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@testim/chrome-version@^1.1.3":
+"@testim/chrome-version@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.4.tgz#86e04e677cd6c05fa230dd15ac223fa72d1d7090"
   integrity sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==
@@ -4427,12 +4427,21 @@ axios@1.1.3:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^1.0.0, axios@^1.4.0:
+axios@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.1.tgz#11fbaa11fc35f431193a9564109c88c1f27b585f"
   integrity sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==
   dependencies:
     follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
+axios@^1.6.5:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+  dependencies:
+    follow-redirects "^1.15.4"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -4951,18 +4960,18 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@117.0.3:
-  version "117.0.3"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-117.0.3.tgz#4a14cc992d572367b99b53c772adcc4c19078e1e"
-  integrity sha512-c2rk2eGK5zZFBJMdviUlAJfQEBuPNIKfal4+rTFVYAmrWbMPYAqPozB+rIkc1lDP/Ryw44lPiqKglrI01ILhTQ==
+chromedriver@121.0.0:
+  version "121.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-121.0.0.tgz#f8d11dce8e5ce4b6ad75e2b84eed17a0eecabfb9"
+  integrity sha512-ZIKEdZrQAfuzT/RRofjl8/EZR99ghbdBXNTOcgJMKGP6N/UL6lHUX4n6ONWBV18pDvDFfQJ0x58h5AdOaXIOMw==
   dependencies:
-    "@testim/chrome-version" "^1.1.3"
-    axios "^1.4.0"
-    compare-versions "^6.0.0"
+    "@testim/chrome-version" "^1.1.4"
+    axios "^1.6.5"
+    compare-versions "^6.1.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.1"
     proxy-from-env "^1.1.0"
-    tcp-port-used "^1.0.1"
+    tcp-port-used "^1.0.2"
 
 ci-info@^3.2.0:
   version "3.8.0"
@@ -5180,7 +5189,7 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
-compare-versions@^6.0.0:
+compare-versions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
   integrity sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==
@@ -6811,6 +6820,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
   integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -11127,7 +11141,7 @@ tar@6.1.11:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tcp-port-used@^1.0.1:
+tcp-port-used@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.2.tgz#9652b7436eb1f4cfae111c79b558a25769f6faea"
   integrity sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==


### PR DESCRIPTION
Reconfigures SWC to include "externalHelpers", making the tool easier to consume.

For a production app there would be bundle size considerations here but since this is meant for dev/testing environments the bundle size increase is not a pressing concern.