### PR TITLE
feat: make chromedriver to peer dependency

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -1,0 +1,19 @@
+{
+  "dependencyTypes": ["prod", "peer"],
+  "semverGroups": [
+    {
+      "label": "use exact version numbers in production and peer",
+      "packages": ["**"],
+      "dependencyTypes": ["prod, peer"],
+      "dependencies": ["**"],
+      "range": ""
+    },
+    {
+        "label": "use carat range for chromedriver in peer",
+        "packages": ["runner"],
+        "dependencyTypes": ["peer"],
+        "dependencies": ["chromedriver"],
+        "range": "^"
+      }
+  ]
+}

--- a/change/@tensile-perf-runner-bfb168e9-52b6-4e18-a6e1-9aedd89c9073.json
+++ b/change/@tensile-perf-runner-bfb168e9-52b6-4e18-a6e1-9aedd89c9073.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: move chromedriver to peer dependency",
+  "packageName": "@tensile-perf/runner",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "beachball:publish": "beachball publish --access public -y",
     "build": "nx run-many --targets=build && nx run runner:linkbinary",
     "change": "beachball change",
-    "check-dependencies": "syncpack list-mismatches --prod --peer",
+    "check-dependencies": "syncpack list-mismatches",
     "lint": "nx affected --target=lint",
     "test": "nx run-many --target=test --all --parallel false",
     "type-check": "nx affected --target=type-check",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@tensile-perf/tree": "0.1.7",
-    "chromedriver": "124.0.3",
     "cli-table": "0.3.11",
     "edgedriver": "5.2.1",
     "ejs": "3.1.9",
@@ -26,7 +25,11 @@
     "@types/express": "4.17.17",
     "@types/express-useragent": "1.0.2",
     "@types/yargs": "17.0.22",
+    "chromedriver": "^125.0.0",
     "fs-extra": "11.1.1"
+  },
+  "peerDependencies": {
+    "chromedriver": "> 121 || < 150"
   },
   "exports": {
     ".": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4984,10 +4984,10 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@124.0.3:
-  version "124.0.3"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-124.0.3.tgz#2818408353ee97005acb887d9f488fe34d5c6d10"
-  integrity sha512-k6Xu9fwDMgi//bGHB944QMmDHF0BBWGk4PAyVZBEuP6wnZMfQP4V6Sv+l/nuAPA006RllS6X07ZpjPwRPS4BaA==
+chromedriver@^125.0.0:
+  version "125.0.3"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-125.0.3.tgz#4c7cf13e54cd3575b88d4376a53d659cabb0ae05"
+  integrity sha512-Qzuk5Wian2o3EVGjtbz6V/jv+pT/AV9246HbG6kUljZXXjsKZLZxqJC+kHR3qEh/wdv4EJD0YwAOWV72v9hogw==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
     axios "^1.6.7"


### PR DESCRIPTION
This PR moves `chromedriver` to be a peer dependency of the project to ensure that multiple versions of Chrome can be leveraged during the development process.