### PR TITLE
feat: export utilities from framework packages

### DIFF
--- a/change/@tensile-perf-react-2734287f-ff90-42fe-9bee-de49d5aa3668.json
+++ b/change/@tensile-perf-react-2734287f-ff90-42fe-9bee-de49d5aa3668.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export utilities",
+  "packageName": "@tensile-perf/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@tensile-perf-web-components-3df7bea3-851c-4771-8d08-042009f66eb2.json
+++ b/change/@tensile-perf-web-components-3df7bea3-851c-4771-8d08-042009f66eb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export utilities",
+  "packageName": "@tensile-perf/web-components",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -7,6 +7,15 @@
 import * as React_2 from 'react';
 
 // @public (undocumented)
+export const injectStyles: (params: RandomCssFromSelectorsParams) => void;
+
+// @public (undocumented)
+export const measureJavascript: JavascriptMeasureFn;
+
+// @public (undocumented)
+export const measureLayout: LayoutMeasureFn;
+
+// @public (undocumented)
 export const TestApp: React_2.FC<TestAppProps<unknown>>;
 
 // @public (undocumented)
@@ -42,6 +51,12 @@ export type TreeItemRenderer<T> = (props: TreeItemRendererProps<T>) => JSX.Eleme
 
 // @public (undocumented)
 export const TreeNode: <T extends RandomTreeNode<unknown>>(props: TreeNodeProps<T>) => JSX.Element;
+
+// @public (undocumented)
+export const usePerformanceMeasure: () => {
+    startMeasure: () => void;
+    endMeasure: () => void;
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react/src/hooks/usePerformanceMeasure.ts
+++ b/packages/react/src/hooks/usePerformanceMeasure.ts
@@ -13,7 +13,7 @@ import { measureJavascript, measureLayout } from '@tensile-perf/tools';
 //     }, []);
 // };
 
-export const useMeasure = () => {
+export const usePerformanceMeasure = () => {
     const startTime = React.useRef<number>(-1);
 
     const startMeasure = () => {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -20,3 +20,6 @@ export type {
     TestMap,
     TreeItemRenderer,
 } from './types.js'
+
+export { usePerformanceMeasure } from './hooks/usePerformanceMeasure.js';
+export { injectStyles, measureLayout, measureJavascript } from '@tensile-perf/tools';

--- a/packages/react/src/test/TestAdd.tsx
+++ b/packages/react/src/test/TestAdd.tsx
@@ -4,14 +4,14 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Tree } from '../tree/Tree.js';
-import { useMeasure } from '../hooks/usePerformanceMeasure.js';
+import { usePerformanceMeasure } from '../hooks/usePerformanceMeasure.js';
 import type { TestRenderFunction } from '../types.js';
 import { TestApp } from './TestApp.js';
 
 export const renderAddTest: TestRenderFunction = ({ fixture, itemRenderer, renderTargetSelector, TestWrapper = TestApp, onComplete }) => {
     const Add = () => {
 
-      const { startMeasure, endMeasure } = useMeasure();
+      const { startMeasure, endMeasure } = usePerformanceMeasure();
       const [added, setAdded] = React.useState(false);
       React.useEffect(() => {
         setTimeout(() => {

--- a/packages/react/src/test/TestMount.tsx
+++ b/packages/react/src/test/TestMount.tsx
@@ -4,14 +4,14 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Tree } from '../tree/Tree.js';
-import { useMeasure } from '../hooks/usePerformanceMeasure.js';
+import { usePerformanceMeasure } from '../hooks/usePerformanceMeasure.js';
 import type { TestRenderFunction } from '../types.js';
 import { TestApp } from './TestApp.js';
 
 export const renderMountTest: TestRenderFunction = ({ fixture, itemRenderer, renderTargetSelector, TestWrapper = TestApp, onComplete }) => {
     const Mount = () => {
 
-        const { startMeasure, endMeasure } = useMeasure();
+        const { startMeasure, endMeasure } = usePerformanceMeasure();
         startMeasure();
         React.useLayoutEffect(() => {
             endMeasure();

--- a/packages/react/src/test/TestRemove.tsx
+++ b/packages/react/src/test/TestRemove.tsx
@@ -4,14 +4,14 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Tree } from '../tree/Tree.js';
-import { useMeasure } from '../hooks/usePerformanceMeasure.js';
+import { usePerformanceMeasure } from '../hooks/usePerformanceMeasure.js';
 import type { TestRenderFunction } from '../types.js';
 import { TestApp } from './TestApp.js';
 
 export const renderRemoveTest: TestRenderFunction = ({ fixture, itemRenderer, renderTargetSelector, TestWrapper = TestApp, onComplete }) => {
     const Remove = () => {
 
-      const { startMeasure, endMeasure } = useMeasure();
+      const { startMeasure, endMeasure } = usePerformanceMeasure();
       const [removed, setRemoved] = React.useState(false);
       React.useEffect(() => {
         setTimeout(() => {

--- a/packages/web-components/etc/web-components.api.md
+++ b/packages/web-components/etc/web-components.api.md
@@ -5,6 +5,21 @@
 ```ts
 
 // @public (undocumented)
+export const injectStyles: (params: RandomCssFromSelectorsParams) => void;
+
+// @public (undocumented)
+export const measureJavascript: JavascriptMeasureFn;
+
+// @public (undocumented)
+export const measureLayout: LayoutMeasureFn;
+
+// @public (undocumented)
+export const measurePerformance: () => {
+    startMeasure: () => void;
+    endMeasure: () => void;
+};
+
+// @public (undocumented)
 export type TestMap = Record<TestType, TestRenderFunction>;
 
 // @public (undocumented)

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -14,3 +14,6 @@ export type {
   TestMap,
   TreeItemRenderer,
 } from './types.js';
+
+export { measurePerformance } from './util/performanceMeasure.js';
+export { injectStyles, measureLayout, measureJavascript } from '@tensile-perf/tools';


### PR DESCRIPTION
This change allows users to depend solely (at least for typical cases) on their framework's package (ex: `@tensile-perf/web-components` for Web Components) without needing to also depend on `@tensile-perf/tools` for some of the measurement utilities.

- exports measurePerformance for Web Components
- exports usePerformanceMeasure for React
- re-exports `@tensile-perf/tools` for WC and React

See: https://github.com/microsoft/fluentui/pull/31713#discussion_r1653478759