### PR TITLE
Allow advanced browser configs

### DIFF
--- a/change/@tensile-perf-runner-18a78ab2-0bec-4971-8f3a-73e2789f629d.json
+++ b/change/@tensile-perf-runner-18a78ab2-0bec-4971-8f3a-73e2789f629d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "allow advanced browser configs",
+  "packageName": "@tensile-perf/runner",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/runner/src/tachometerConfig.ts
+++ b/packages/runner/src/tachometerConfig.ts
@@ -39,11 +39,8 @@ const makeConfigJson: MakeConfigJsonFn = ({ numRuns, browsers, file, test, fixtu
       name: `${file} - ${fixtureFileName} - ${test}`,
       url: getUrl(),
       measurement: 'global',
-      browser: {
-        name: browser,
-        // binary: binaries[browser],
-      }
-    }
+      browser,
+    };
   }))
 
   const json: ConfigFile = {


### PR DESCRIPTION
This PR allows for browser configurations beyond setting the `name` field:

```ts
export default {
    browsers: [{
        name: "chrome",
        headless: true,
    }],
};
```